### PR TITLE
Remove icons from the projects section

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -4,7 +4,7 @@ import Card from "@material-ui/core/Card";
 import CardActionArea from "@material-ui/core/CardActionArea";
 import CardContent from "@material-ui/core/CardContent";
 import CardMedia from "@material-ui/core/CardMedia";
-import { FaInstagram, FaLinkedin, FaGithub } from "react-icons/fa";
+import { FaGithub } from "react-icons/fa";
 import { Name,Tagline, SocialIcons, SocialIconLink } from "./cardElement";
 
 const useStyles = makeStyles({
@@ -39,20 +39,6 @@ export default function MediaCard(props) {
               aria-label="Github"
             >
               <FaGithub />
-            </SocialIconLink>
-            <SocialIconLink
-              href={props.linkedin}
-              target="_blank"
-              aria-label="Linkedin"
-            >
-              <FaLinkedin />
-            </SocialIconLink>
-            <SocialIconLink
-              href={props.instagram}
-              target="_blank"
-              aria-label="Instagram"
-            >
-              <FaInstagram />
             </SocialIconLink>
           </SocialIcons>
         </CardContent>

--- a/src/components/card/cardElement.js
+++ b/src/components/card/cardElement.js
@@ -14,7 +14,6 @@ export const SocialIcons = styled.div`
   justify-content:space-around;
   align-items: center;
   width: 240px;
-  margin-left:10px
 `;
 
 export const SocialIconLink = styled.a`

--- a/src/components/projects/projects.jsx
+++ b/src/components/projects/projects.jsx
@@ -37,9 +37,7 @@ function createCard(projectData) {
         image={projectData.image}
         name={projectData.name}
         tagline={projectData.tagline}
-        github={projectData.github}
-        linkedin={projectData.linkedin}
-        instagram = {projectData.instagram}    
+        github={projectData.github}   
       />
       </Grid>
     );

--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -37,9 +37,7 @@ function createCard(projectData) {
         image={projectData.image}
         name={projectData.name}
         tagline={projectData.tagline}
-        github={projectData.github}
-        linkedin={projectData.linkedin}
-        instagram = {projectData.instagram}    
+        github={projectData.github}    
       />
       </Grid>
     );

--- a/src/pages/teamData.jsx
+++ b/src/pages/teamData.jsx
@@ -83,7 +83,7 @@ const teamData = [
   },
   {
     name: "Debasish Mishra",
-    image: require("../assets/data/debasish.jpg").default,
+    image: require("../assets/data/debasish.jpeg").default,
     tagline: "Web Developer",
     github: "https://github.com/debasish-creator",
     linkedin: "https://www.linkedin.com/in/debasish-mishra-86135b129/",


### PR DESCRIPTION
Create a new branch "projects-section/remove-links" to make the changes

Remove the Instagram and Linkedin icons from the `<Card/>` component, and 
their props from the `<Projects/>` component.

Align the Github icon along the mid axis by removing 
```CSS
 margin-right :10px;
```

Verify the cards are center-aligned and maintained responsiveness.

![webwiz](https://user-images.githubusercontent.com/72919092/118388889-f4f67a00-b61e-11eb-86f1-1238945f41e6.PNG)

Expecting reviews

